### PR TITLE
Address issues 15-17

### DIFF
--- a/content/docs/authoring.md
+++ b/content/docs/authoring.md
@@ -33,7 +33,7 @@ The goal is to preserve the Carpentries teaching vocabulary while letting Hextra
 ### Challenge, hint, and solution
 
 ```text
-{{</* challenge title="Warm-up exercise" */>}}
+{{</* challenge title="Warm-up exercise" subtitle="Work through the prompt before the discussion." */>}}
 Prompt the learner to do something concrete.
 
 {{</* hint */>}}
@@ -47,6 +47,7 @@ Provide a worked answer or expected approach.
 ```
 
 This renders as a warm challenge panel with nested collapsible hint and solution blocks.
+Use `subtitle` only when the challenge needs an extra framing line; omit it when the title is enough.
 
 ### Callout box types
 

--- a/content/docs/components.md
+++ b/content/docs/components.md
@@ -133,6 +133,25 @@ layout = "hextra-home"
 `lesson/overview` renders a compact table built from the `objectives` lists of all episode pages.
 `lesson/schedule` renders a timetable with an optional untimed setup row, a cumulative start-time column, the episode title, and the episode questions.
 `lesson/authors` renders a compact table of contributors from the repository root `AUTHORS` file on the homepage.
+`lesson/meta` reuses lesson metadata from `hugo.toml` directly inside Markdown body content.
+
+Use `lesson/meta` when the homepage or another content page should echo the configured lesson title, tagline, or description without duplicating that text:
+
+```text
+{{</* lesson/meta "title" */>}}
+{{</* lesson/meta "tagline" */>}}
+{{</* lesson/meta "description" */>}}
+{{</* lesson/meta "siteTitle" */>}}
+```
+
+Supported keys:
+
+- `title`: `params.lesson.title`, falling back to `title`
+- `tagline`: `params.lesson.tagline`, falling back to `params.lesson.description`
+- `description`: `params.lesson.description`, falling back to `params.lesson.tagline`
+- `siteTitle`: the site-level `title`
+
+Unsupported keys fail the build clearly so typos do not silently render empty content.
 
 The authors file is intentionally lightweight. One contributor per line is enough:
 

--- a/content/docs/components.md
+++ b/content/docs/components.md
@@ -13,7 +13,7 @@ For a particle-physics-focused Hextra feature walkthrough, see
 ## Challenge, hint, and solution
 
 ```text
-{{</* challenge title="Warm-up exercise" */>}}
+{{</* challenge title="Warm-up exercise" subtitle="Try the prompt on your own before the group debrief." */>}}
 Prompt the learner to do something concrete.
 
 {{</* hint */>}}
@@ -27,6 +27,7 @@ Provide the worked answer.
 ```
 
 Use these for real learning activities, not just decorative emphasis.
+The `subtitle` parameter is optional, so leave it out when the challenge title already does enough work on its own.
 
 ## Callouts
 

--- a/content/docs/frontmatter.md
+++ b/content/docs/frontmatter.md
@@ -25,6 +25,9 @@ Use episode front matter to describe both the teaching flow and the navigation m
 
 The lesson homepage usually lives in `content/_index.md` and keeps `layout = "hextra-home"`.
 That page can hold the homepage content blocks in [Components]({{< relref "/docs/components" >}}).
+Shared lesson metadata such as `params.lesson.title`, `params.lesson.tagline`, and
+`params.lesson.description` belongs in `hugo.toml`, and `lesson/meta` can reuse those values
+inside Markdown body content when you want homepage copy to stay aligned with the config.
 
 If you want an authors block on the homepage, add a root-level `AUTHORS` file. The `lesson/authors`
 shortcode reads that file directly and renders the contributors there.

--- a/content/docs/frontmatter.md
+++ b/content/docs/frontmatter.md
@@ -11,7 +11,7 @@ Use episode front matter to describe both the teaching flow and the navigation m
 - `weight`: numeric order in the lesson
 - `questions`: list of learner-facing questions rendered near the top
 - `objectives`: list of learning goals rendered near the top
-- `keypoints`: list of recap points rendered near the bottom
+- `keypoints`: list of recap points rendered near the bottom, with inline Markdown support for emphasis and code spans
 
 ## Optional episode fields
 

--- a/layouts/key-points/single.html
+++ b/layouts/key-points/single.html
@@ -1,5 +1,6 @@
 {{ define "main" }}
   {{ $episodes := sort (where site.RegularPages "Section" "episodes") "Weight" }}
+  {{ $inlineRender := dict "display" "inline" }}
   {{ $scratch := newScratch }}
   {{ $scratch.Set "keypointCount" 0 }}
   {{ range $episodes }}
@@ -75,10 +76,9 @@
                 </div>
                 <ul class="hx:mt-5 hx:space-y-3">
                   {{ range $episode.Params.keypoints }}
-                    {{ $item := replaceRE "`([^`]+)`" "<code>$1</code>" (htmlEscape .) }}
                     <li class="hx:flex hx:gap-3">
                       <span class="hx:mt-1 hx:h-2.5 hx:w-2.5 hx:flex-none hx:rounded-full hx:bg-primary-500 hx:dark:bg-primary-400"></span>
-                      <span>{{ $item | safeHTML }}</span>
+                      <span>{{ $episode.RenderString $inlineRender . }}</span>
                     </li>
                   {{ end }}
                 </ul>

--- a/layouts/partials/episode-content.html
+++ b/layouts/partials/episode-content.html
@@ -1,5 +1,6 @@
 {{ $page := .page }}
 {{ $minutes := add ($page.Params.teaching | default 0) ($page.Params.exercises | default 0) }}
+{{ $inlineRender := dict "display" "inline" }}
 {{ $episodeID := "" }}
 {{ with $page.File }}
   {{ if .Dir }}
@@ -51,8 +52,7 @@
       <h2 id="{{ printf "%s-key-points" $episodeID }}">Key Points</h2>
       <ul>
         {{ range . }}
-          {{ $item := replaceRE "`([^`]+)`" "<code>$1</code>" (htmlEscape .) }}
-          <li>{{ $item | safeHTML }}</li>
+          <li>{{ $page.RenderString $inlineRender . }}</li>
         {{ end }}
       </ul>
     </section>

--- a/layouts/shortcodes/challenge.html
+++ b/layouts/shortcodes/challenge.html
@@ -3,7 +3,7 @@
     <span class="lesson-challenge-label">Challenge</span>
     <div class="lesson-challenge-heading">
       {{ with .Get "title" }}<h3 class="lesson-challenge-title">{{ . }}</h3>{{ end }}
-      <p class="lesson-challenge-subtitle">Use short, answerable prompts that work well in workshops and still read clearly in an all-in-one lesson view.</p>
+      {{ with .Get "subtitle" }}<p class="lesson-challenge-subtitle">{{ . }}</p>{{ end }}
     </div>
   </div>
   <div class="lesson-challenge-body">

--- a/layouts/shortcodes/lesson/meta.html
+++ b/layouts/shortcodes/lesson/meta.html
@@ -1,0 +1,31 @@
+{{- $supportedKeys := "title, tagline, description, siteTitle" -}}
+{{- $rawKey := "" -}}
+{{- if .IsNamedParams -}}
+  {{- with .Get "key" -}}
+    {{- $rawKey = . -}}
+  {{- end -}}
+{{- else -}}
+  {{- with .Get 0 -}}
+    {{- $rawKey = . -}}
+  {{- end -}}
+{{- end -}}
+{{- $key := lower (strings.TrimSpace $rawKey) -}}
+
+{{- if not $key -}}
+  {{- errorf "The lesson/meta shortcode requires a metadata key at %s. Supported keys: %s" .Position $supportedKeys -}}
+{{- end -}}
+
+{{- $value := "" -}}
+{{- if eq $key "title" -}}
+  {{- $value = site.Params.lesson.title | default site.Title -}}
+{{- else if eq $key "tagline" -}}
+  {{- $value = site.Params.lesson.tagline | default site.Params.lesson.description -}}
+{{- else if eq $key "description" -}}
+  {{- $value = site.Params.lesson.description | default site.Params.lesson.tagline -}}
+{{- else if or (eq $key "sitetitle") (eq $key "site-title") -}}
+  {{- $value = site.Title -}}
+{{- else -}}
+  {{- errorf "Unsupported lesson/meta key %q at %s. Supported keys: %s" $rawKey .Position $supportedKeys -}}
+{{- end -}}
+
+{{- $value -}}


### PR DESCRIPTION
- Issue #15: feat: add lesson metadata shortcode
- Issue #16: feat: make challenge subtitles optional
- Issue #17: fix: render keypoints as inline markdown