### PR TITLE
docs: clarify template setup metadata

### DIFF
--- a/content/docs/quickstart.md
+++ b/content/docs/quickstart.md
@@ -25,11 +25,15 @@ Use this order in a fresh lesson repository:
 
 ## Create a new lesson
 
-1. Create a new repository from `hugo-styles-template`.
+1. Create a new repository from
+   [`hugo-styles-template`](https://github.com/oer-particle-physics/hugo-styles-template)
+   by clicking **Use this template** at the top right of the repository page.
 2. Run `hugo version` and `hugo server` to confirm the local toolchain before editing lesson content.
 3. Update the site metadata in `hugo.toml`.
-   In particular, `params.lesson.repo` is used for the source and edit links in the page footer.
-   The top-nav GitHub icon is configured separately in `[[menus.main]]`.
+   Change both the site-level `title` and `params.lesson.title`; the former controls Hugo's site title,
+   while the latter is reused by lesson components and metadata snippets.
+   Update `params.lesson.repo` and `params.lesson.docsRepo` because they are used for the source, edit, and citation links in the page footer.
+   The top-nav GitHub icon is configured separately in `[[menus.main]]`, so update that menu URL too.
    If you plan to deploy on GitHub Pages, set `baseURL` to `https://<account>.github.io/<repo>/`.
    In the repository settings, enable Pages and select `GitHub Actions` as the source before the first push to `main`.
 4. Add episodes with `hugo new --kind episode episodes/my-episode/index.md`.

--- a/content/docs/troubleshooting.md
+++ b/content/docs/troubleshooting.md
@@ -21,6 +21,20 @@ Check that:
 - the page does not set `[tabs] sync = false`
 - you are using Hextra's `tabs` and `tab` shortcodes, not a copied custom variant
 
+## The sidebar or browser title still says Example Lesson
+
+Changing `content/_index.md` only updates the homepage content. In a repository created from
+`hugo-styles-template`, also update these values in `hugo.toml`:
+
+- site-level `title`
+- `params.lesson.title`
+- `params.lesson.repo`
+- `params.lesson.docsRepo`
+- the GitHub URL in `[[menus.main]]`
+
+The sidebar and browser title can come from Hugo metadata rather than visible Markdown text, so
+`grep` may not find the old title in `content/`.
+
 ## A glossary or profile link is broken
 
 The shortcode target should match the content slug, for example:


### PR DESCRIPTION
Closes #33.

Closes #35.