### PR TITLE
fix: keep internal banner links in same tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.hugo-versioned-cache/
 /.lycheecache
 /node_modules/
+/test-results/
 /.cache/
 /.DS_Store
 /.idea/

--- a/content/docs/hextra-features/index.md
+++ b/content/docs/hextra-features/index.md
@@ -248,7 +248,7 @@ The dismissible banner at the top identifies this documentation as a live demo. 
 ```toml
 [params.banner]
   key = "hugo-styles-feature-demo-v1"
-  message = "This documentation is a live feature demo."
+  message = "This documentation is a live feature demo. See the [feature guide](/docs/hextra-features/)."
 
 [params.search]
   enable = true
@@ -258,7 +258,7 @@ The dismissible banner at the top identifies this documentation as a live demo. 
   default = "system"
   displayToggle = true
 ```
-Changing the banner key makes a revised announcement visible even to readers who dismissed an older one.
+Use a root-relative path for an internal banner link so Hugo applies the site's base path and keeps navigation in the same tab. Changing the banner key makes a revised announcement visible even to readers who dismissed an older one.
 {{< /details >}}
 
 ## Markdown context menu

--- a/hugo.toml
+++ b/hugo.toml
@@ -50,7 +50,7 @@ disableKinds = ["taxonomy", "term", "RSS"]
 
 [params.banner]
   key = "hugo-styles-feature-demo-v1"
-  message = "This documentation is a live feature demo. See the [feature guide](https://oer-particle-physics.github.io/hugo-styles/docs/hextra-features/)."
+  message = "This documentation is a live feature demo. See the [feature guide](/docs/hextra-features/)."
 
 [params.search]
   enable = true

--- a/tests/browser/features.spec.ts
+++ b/tests/browser/features.spec.ts
@@ -13,6 +13,9 @@ test("banner dismissal, search, and theme controls work", async ({ page }, testI
 
   const banner = page.locator(".hextra-banner");
   await expect(banner).toBeVisible();
+  const bannerFeatureLink = banner.getByRole("link", { name: "feature guide" });
+  await expect(bannerFeatureLink).toHaveAttribute("href", "/docs/hextra-features/");
+  expect(await bannerFeatureLink.getAttribute("target")).toBeNull();
   await page.getByRole("button", { name: "Close banner" }).click();
   expect(await page.evaluate(() => localStorage.getItem("hugo-styles-feature-demo-v1"))).toBe("0");
   await page.reload();


### PR DESCRIPTION
## Summary

- configure the same-site banner link as an internal root-relative destination
- document why internal banner links should remain root-relative
- assert the resolved URL and same-tab behavior in Playwright
- ignore Playwright's generated `test-results/` directory

## Root cause

Hextra classifies Markdown destinations beginning with `http` as external and adds `target="_blank"`. The banner used an absolute URL even though it points to this site. A root-relative destination lets Hugo add the active base path while Hextra correctly treats the link as internal.

## Validation

- Hugo production build with warnings treated as errors
- Playwright Chromium suite: 9 passed, 7 intentional viewport-specific skips
- versioned build of the current checkout and `v0.4.0`
- rendered banner assertion under the `/hugo-styles/` project base path
