### PR TITLE
fix: rewrite minified version menu links

### DIFF
--- a/scripts/build-versioned-site.py
+++ b/scripts/build-versioned-site.py
@@ -381,9 +381,7 @@ def apply_version_menu(
 
 def rewrite_version_menu_links(destination: Path, menu_items: list[BuildTarget]) -> None:
     replacements = {
-        f'href="{version_menu_placeholder(item)}"': (
-            f'href="{html.escape(item.menu_path, quote=True)}"'
-        )
+        version_menu_placeholder(item): html.escape(item.menu_path, quote=True)
         for item in menu_items
     }
     for path in destination.rglob("*.html"):

--- a/scripts/tests/test_build_versioned_site.py
+++ b/scripts/tests/test_build_versioned_site.py
@@ -215,14 +215,16 @@ class TargetTests(unittest.TestCase):
             page.parent.mkdir(parents=True)
             page.write_text(
                 f'<a href="{placeholders[0]}">Latest</a>'
-                f'<a href="{placeholders[1]}">v1.2.0</a>',
+                f'<a href="{placeholders[1]}">v1.2.0 quoted</a>'
+                f'<a href={placeholders[1]}>v1.2.0 minified</a>',
                 encoding="utf-8",
             )
             builder.rewrite_version_menu_links(output, targets)
             self.assertEqual(
                 page.read_text(encoding="utf-8"),
                 '<a href="/lesson/">Latest</a>'
-                '<a href="/lesson/versions/v1.2.0/">v1.2.0</a>',
+                '<a href="/lesson/versions/v1.2.0/">v1.2.0 quoted</a>'
+                '<a href=/lesson/versions/v1.2.0/>v1.2.0 minified</a>',
             )
 
     def test_current_checkout_avoids_primary_ref_in_detached_head(self) -> None:


### PR DESCRIPTION
## Summary

- rewrite version-menu placeholders independently of HTML attribute quoting
- cover both normal quoted markup and Hugo's minified unquoted markup

## Root cause

The transactional versioned builder replaced only `href="placeholder"`. Production builds enable Hugo minification, which emits `href=placeholder`, leaving the internal token in the deployed menu and causing 404s. The link-check build uses `--no-minify`, so it did not expose the mismatch.

## Validation

- 10 Python version-builder tests pass
- minified versioned build of the current checkout and `v0.4.0`
- all 70 rendered HTML files checked for unresolved placeholders
- rendered Latest and v0.4.0 menu paths checked under the `/hugo-styles/` project base URL
