### PR TITLE
fix: validate refreshed template checkout

### DIFF
--- a/dist/template-files/.github/workflows/refresh-vendored-modules.yml
+++ b/dist/template-files/.github/workflows/refresh-vendored-modules.yml
@@ -24,7 +24,7 @@ jobs:
         ./scripts/sync-template-files.sh
         hugo mod vendor
       verify-command: |
-        python3 scripts/build-versioned-site.py
+        python3 scripts/build-versioned-site.py --use-current-checkout
         hugo --gc --minify --noBuildLock --destination /tmp/site
       pr-title: "chore: refresh vendored Hugo modules"
       pr-body: |


### PR DESCRIPTION
## Summary

- make downstream refresh verification build the files refreshed in the current checkout

## Root cause

The managed refresh workflow modifies `go.mod`, `_vendor/`, workflows, and the versioned builder, then invokes the builder without `--use-current-checkout`. In a detached Actions checkout, the builder resolves Latest from `origin/main`, so it validates the pre-refresh commit instead of the refreshed working tree.

## Validation

- actionlint passes for the managed workflow
- an exact v0.5.2 downstream refresh was built both ways, confirming the old invocation checked out pre-refresh `main`
- the corrected invocation builds the refreshed v0.5.2 vendor snapshot and leaves no version-menu placeholders in rendered HTML
