### PR TITLE
fix: correct edit links and downstream update flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,26 +65,9 @@ The example site in this repository doubles as the public documentation for the 
 
 Downstream lessons should **not** copy layouts, assets, or shortcodes out of this repository. Instead they should import a released version of `hugo-styles` as a Hugo Module.
 
-Typical downstream update flow:
-
-```bash
-hugo mod get -u github.com/oer-particle-physics/hugo-styles@latest
-hugo mod tidy
-hugo
-```
-
-For a smoother maintenance experience, downstream lesson repositories should enable Dependabot for `gomod` updates so module bumps arrive as pull requests.
-
 The `hugo-styles-template` repository commits `_vendor/` so lesson authors can run local builds with Hugo Extended alone.
-Template maintainers still use Go when refreshing `go.mod`/`go.sum`, managed maintainer files, and `_vendor/`,
-either through the **Refresh vendored Hugo modules** workflow or locally with:
-
-```bash
-hugo mod get -u github.com/oer-particle-physics/hugo-styles@latest
-hugo mod tidy
-./scripts/sync-template-files.sh
-hugo mod vendor
-```
+Lesson repositories receive released module updates through the scheduled **Refresh vendored Hugo modules** workflow.
+It updates the pinned module, refreshes `_vendor/` and the managed maintainer files, and opens a pull request for review.
 
 The shared sync currently manages:
 
@@ -214,4 +197,4 @@ lychee --cache --config lychee.toml --no-progress --root-dir .cache/linkcheck-si
 ```
 
 The `release-please` workflow expects a `RELEASE_PLEASE_TOKEN` secret so the generated release PRs and tags can trigger follow-up GitHub Actions runs normally.
-Once the release PR is merged, downstream lesson repositories pick up the new version through `hugo mod get -u ...`, the **Refresh vendored Hugo modules** workflow, or Dependabot PRs.
+Once the release PR is merged, downstream lesson repositories pick up the new version through the **Refresh vendored Hugo modules** workflow.

--- a/content/docs/deployment.md
+++ b/content/docs/deployment.md
@@ -52,8 +52,8 @@ and documented.
 - it avoids the old branch-publishing coupling
 - it matches the shared-module update model more naturally
 
-The template repo already includes the workflow and Dependabot setup required for a typical lesson repository.
-When you update `hugo-styles`, run `./scripts/sync-template-files.sh` so those managed workflow files stay aligned with the pinned module version.
+The template repository includes the deployment and scheduled module-refresh workflows required for a typical lesson repository.
+The refresh workflow keeps the managed workflow files aligned with the pinned `hugo-styles` version.
 
 ## Versioned lesson archives
 

--- a/content/docs/hugo-styles-maintenance.md
+++ b/content/docs/hugo-styles-maintenance.md
@@ -69,4 +69,3 @@ resolves to the semantic release rather than a pseudo-version.
 After release, downstream lesson repositories consume updates via:
 
 - `hugo-styles-template` vendored refresh PRs (`go.mod`, `go.sum`, managed files, `_vendor/`)
-- direct-module Dependabot PRs or manual `hugo mod get -u ...`

--- a/content/docs/troubleshooting.md
+++ b/content/docs/troubleshooting.md
@@ -62,11 +62,6 @@ Aggregated pages such as `All-in-One`, `Key Points`, and `External Links` are in
 
 ## A downstream lesson does not pick up a shared-module fix
 
-Run:
-
-```bash
-hugo mod get -u github.com/oer-particle-physics/hugo-styles@latest
-hugo mod tidy
-```
-
-Then rebuild locally. If the change still does not appear, look for a local override in `layouts/`, `assets/`, or `archetypes/`.
+First confirm that the fix has been included in a `hugo-styles` release. Then run the lesson repository's
+**Refresh vendored Hugo modules** workflow and merge the pull request it opens.
+If the change still does not appear after rebuilding, look for a local override in `layouts/`, `assets/`, or `archetypes/`.

--- a/content/docs/updates.md
+++ b/content/docs/updates.md
@@ -19,7 +19,7 @@ The v0.5 safety changes are intentional:
 
 Fix validation errors rather than bypassing them. Existing content URLs and shortcode names remain compatible.
 
-## Recommended path: template + automated vendor refresh (no local Go)
+## Update through the scheduled refresh workflow
 
 For repositories created from `hugo-styles-template`, the intended update flow is:
 
@@ -51,18 +51,6 @@ but it can fail during the pull-request step once an upstream release updates `.
 `_vendor/` is a committed snapshot of Hugo module dependencies pinned by `go.mod` and `go.sum`.
 Committing it keeps lesson builds reproducible and lets authors run `hugo server` without local Go.
 
-### Refresh locally (optional, if Go is available)
-
-If you do have Go locally and want to refresh manually:
-
-```bash
-hugo mod get -u github.com/oer-particle-physics/hugo-styles@latest
-hugo mod tidy
-./scripts/sync-template-files.sh
-hugo mod vendor
-python3 scripts/build-versioned-site.py
-```
-
 The sync helper copies the managed maintainer files from the exact pinned `hugo-styles`
 module version. That currently includes:
 
@@ -75,22 +63,7 @@ module version. That currently includes:
 - `.github/workflows/reusable-refresh-vendored-modules.yml`
 
 That keeps the committed maintainer files aligned with `go.mod` rather than downloading an unrelated head revision.
-
-## Direct module mode (without `_vendor/`)
-
-If a lesson repository imports `github.com/oer-particle-physics/hugo-styles` directly (without committed `_vendor/`),
-enable Dependabot for `gomod` so updates arrive as pull requests.
-
-Manual fallback:
-
-```bash
-hugo mod get -u github.com/oer-particle-physics/hugo-styles@latest
-hugo mod tidy
-hugo mod graph
-hugo
-```
-
-Review the rendered preview before merging a module bump, especially when the changelog mentions a breaking change.
+Review the rendered preview and workflow checks before merging the refresh pull request, especially when the changelog mentions a breaking change.
 
 ## Override strategy
 

--- a/layouts/partials/custom/footer.html
+++ b/layouts/partials/custom/footer.html
@@ -9,7 +9,9 @@
 {{ $poweredByURL := "https://oer-particle-physics.github.io/hugo-styles/" }}
 {{ $licenseName := site.Params.lesson.licenseName }}
 {{ with $page.File }}
-  {{ $path = .Path }}
+  {{ $sourceDir := replace (strings.TrimPrefix .FileInfo.Meta.BaseDir .FileInfo.Meta.SourceRoot) "\\" "/" }}
+  {{ $sourceDir = strings.TrimPrefix "/" $sourceDir }}
+  {{ $path = urls.JoinPath $sourceDir (replace .Path "\\" "/") }}
 {{ end }}
 {{ with $page.Lastmod }}
   {{ $lastUpdated = partial "utils/format-date.html" . }}

--- a/tests/browser/lesson.spec.ts
+++ b/tests/browser/lesson.spec.ts
@@ -2,6 +2,17 @@ import { expect, test } from "@playwright/test";
 
 const episodePath = "/episodes/01-introduction/";
 
+test("footer edit links include the repository content path", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop-chromium", "Link generation is viewport-independent.");
+
+  await page.goto(episodePath);
+
+  await expect(page.getByRole("link", { name: "Edit this page" })).toHaveAttribute(
+    "href",
+    "https://github.com/oer-particle-physics/hugo-styles/edit/main/content/episodes/01-introduction/index.md",
+  );
+});
+
 test("episode controls respect desktop and mobile breakpoints", async ({ page }, testInfo) => {
   await page.goto(episodePath);
 


### PR DESCRIPTION
## Summary

- include repository-relative content paths in footer edit links
- add regression coverage for the exact edit URL
- make scheduled refresh PRs the only documented downstream update path

## Why

Hugo `.File.Path` is relative to the content root, so footer edit URLs omitted `content/` and opened non-existent GitHub paths. Downstream documentation also still described Dependabot and manual module updates after the template moved to the scheduled refresh workflow.

## Impact

Downstream lessons receive working “Edit this page” links after the next `hugo-styles` release and refresh. Custom content directories remain supported. The upstream repository’s own Dependabot configuration is unchanged.

## Validation

- `hugo --gc --minify --panicOnWarning`
- `go test ./... && go vet ./...` in `cmd/hugo-styles-migrate`
- `python3 -m unittest discover -s scripts/tests -v`
- `npm run check:flexsearch`
- `npm run check:medium-zoom`
- `npm run test:browser` (10 passed, 8 intentionally skipped)
- `git diff --check`