### PR TITLE
fix: isolate docs banner from downstream sites

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,7 @@ jobs:
     with:
       site-root: .
       go-version-file: go.mod
+      hugo-config: "hugo.toml,hugo-docs.toml"
       setup-node: true
       node-version: "22"
       prepare-command: |
@@ -32,5 +33,5 @@ jobs:
         (cd cmd/hugo-styles-migrate && go test ./... && go vet ./...)
       validation-command: |
         (cd cmd/hugo-styles-migrate && go run . check ../..)
-        hugo --panicOnWarning --destination .cache/current-site
+        hugo --config hugo.toml,hugo-docs.toml --panicOnWarning --destination .cache/current-site
         npm run test:browser

--- a/.github/workflows/reusable-pages.yml
+++ b/.github/workflows/reusable-pages.yml
@@ -10,6 +10,9 @@ on:
       go-version-file:
         type: string
         default: "go.mod"
+      hugo-config:
+        type: string
+        default: "hugo.toml"
       setup-node:
         type: boolean
         default: false
@@ -110,7 +113,7 @@ jobs:
         run: git fetch --prune origin '+refs/heads/*:refs/remotes/origin/*' --tags
 
       - name: Build link-check artifact
-        run: python3 scripts/build-versioned-site.py --base-url / --destination .cache/linkcheck-site --no-minify --use-current-checkout
+        run: python3 scripts/build-versioned-site.py --config "${{ inputs.hugo-config }}" --base-url / --destination .cache/linkcheck-site --no-minify --use-current-checkout
 
       - name: Check rendered links
         uses: lycheeverse/lychee-action@v2
@@ -134,7 +137,7 @@ jobs:
           key: ${{ steps.restore-lychee-cache.outputs.cache-primary-key }}
 
       - name: Build deploy artifact
-        run: python3 scripts/build-versioned-site.py --base-url "${{ steps.pages.outputs.base_url }}/" --use-current-checkout --force
+        run: python3 scripts/build-versioned-site.py --config "${{ inputs.hugo-config }}" --base-url "${{ steps.pages.outputs.base_url }}/" --use-current-checkout --force
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5

--- a/README.md
+++ b/README.md
@@ -90,8 +90,11 @@ For downstream lesson authors, the practical prerequisites are:
 Node.js is only needed in this repository when maintainers refresh vendored frontend assets or run browser tests.
 
 ```bash
-hugo server
+hugo server --config hugo.toml,hugo-docs.toml
 ```
+
+The secondary config keeps documentation-demo settings local to this repository instead of
+exporting them to lessons that import `hugo-styles` as a module.
 
 ## Validation and tests
 
@@ -122,6 +125,7 @@ Rendered-site link checks use `lychee` against a local build that mirrors the Gi
 
 ```bash
 python3 scripts/build-versioned-site.py --use-current-checkout \
+  --config hugo.toml,hugo-docs.toml \
   --base-url / --destination .cache/linkcheck-site --no-minify
 lychee --cache --config lychee.toml --no-progress --root-dir .cache/linkcheck-site '.cache/linkcheck-site/**/*.html'
 ```
@@ -190,8 +194,9 @@ python3 -m unittest discover -s scripts/tests -v
 npm run check:flexsearch
 npm run check:medium-zoom
 npm run test:browser
-hugo --gc --minify --panicOnWarning
+hugo --config hugo.toml,hugo-docs.toml --gc --minify --panicOnWarning
 python3 scripts/build-versioned-site.py --use-current-checkout \
+  --config hugo.toml,hugo-docs.toml \
   --base-url / --destination .cache/linkcheck-site --no-minify
 lychee --cache --config lychee.toml --no-progress --root-dir .cache/linkcheck-site '.cache/linkcheck-site/**/*.html'
 ```

--- a/content/docs/hugo-styles-maintenance.md
+++ b/content/docs/hugo-styles-maintenance.md
@@ -38,7 +38,7 @@ Before merging a release PR or sanity-checking a release candidate:
 1. run `go test ./...` and `go vet ./...` in `cmd/hugo-styles-migrate`
 2. run `python3 -m unittest discover -s scripts/tests -v`
 3. run `npm ci`, both `npm run check:*` asset checks, and `npm run test:browser`
-4. run `hugo --gc --minify --panicOnWarning`
+4. run `hugo --config hugo.toml,hugo-docs.toml --gc --minify --panicOnWarning`
 5. build the current checkout and configured archived refs with `--use-current-checkout`
 6. run `lychee` against that versioned output
 7. confirm the `RELEASE_PLEASE_TOKEN` secret is available, then merge the release PR
@@ -50,8 +50,9 @@ npm ci
 npm run check:flexsearch
 npm run check:medium-zoom
 npm run test:browser
-hugo --gc --minify --panicOnWarning
+hugo --config hugo.toml,hugo-docs.toml --gc --minify --panicOnWarning
 python3 scripts/build-versioned-site.py --use-current-checkout \
+  --config hugo.toml,hugo-docs.toml \
   --base-url / --destination .cache/versioned-site --no-minify
 lychee --cache --config lychee.toml --no-progress \
   --root-dir .cache/versioned-site '.cache/versioned-site/**/*.html'

--- a/hugo-docs.toml
+++ b/hugo-docs.toml
@@ -1,0 +1,3 @@
+[params.banner]
+  key = "hugo-styles-feature-demo-v1"
+  message = "This documentation is a live feature demo. See the [feature guide](/docs/hextra-features/)."

--- a/hugo.toml
+++ b/hugo.toml
@@ -48,10 +48,6 @@ disableKinds = ["taxonomy", "term", "RSS"]
   default = "system"
   displayToggle = true
 
-[params.banner]
-  key = "hugo-styles-feature-demo-v1"
-  message = "This documentation is a live feature demo. See the [feature guide](/docs/hextra-features/)."
-
 [params.search]
   enable = true
   type = "flexsearch"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   ],
   webServer: {
     command:
-      "hugo server --disableFastRender --bind 127.0.0.1 --port 13131 --baseURL http://127.0.0.1:13131/",
+      "hugo server --config hugo.toml,hugo-docs.toml --disableFastRender --bind 127.0.0.1 --port 13131 --baseURL http://127.0.0.1:13131/",
     url: "http://127.0.0.1:13131/",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/scripts/build-versioned-site.py
+++ b/scripts/build-versioned-site.py
@@ -224,7 +224,29 @@ def load_hugo_config(
     hugo_bin: str,
     base_url: str | None,
     cache_dir: Path,
+    *,
+    allow_missing_config_files: bool = False,
 ) -> dict:
+    config_files = [item.strip() for item in config_name.split(",") if item.strip()]
+    if not config_files:
+        raise BuildError("At least one Hugo config file must be specified.")
+
+    available_config_files: list[str] = []
+    missing_config_files: list[str] = []
+    for config_file in config_files:
+        path = Path(config_file)
+        candidate = path if path.is_absolute() else site_root / path
+        if candidate.is_file():
+            available_config_files.append(config_file)
+        else:
+            missing_config_files.append(config_file)
+
+    if missing_config_files and not allow_missing_config_files:
+        missing = ", ".join(missing_config_files)
+        raise BuildError(f"Hugo config file not found in {site_root}: {missing}")
+    if not available_config_files:
+        raise BuildError(f"No Hugo config files found in {site_root}: {config_name}")
+
     command = [
         hugo_bin,
         "config",
@@ -232,7 +254,7 @@ def load_hugo_config(
         "--format",
         "json",
         "--config",
-        config_name,
+        ",".join(available_config_files),
         "--cacheDir",
         str(cache_dir),
     ]
@@ -634,6 +656,7 @@ def target_config(
         hugo_bin,
         None,
         cache_dir,
+        allow_missing_config_files=True,
     )
     return apply_version_menu(config, versioning, menu_targets)
 

--- a/scripts/tests/test_build_versioned_site.py
+++ b/scripts/tests/test_build_versioned_site.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -27,6 +29,80 @@ class URLTests(unittest.TestCase):
             builder.join_url("https://example.org/lesson/", "versions", "v1.2.0"),
             "https://example.org/lesson/versions/v1.2.0/",
         )
+
+
+class ConfigTests(unittest.TestCase):
+    def test_missing_secondary_config_is_only_allowed_for_historical_builds(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_name:
+            site = Path(temp_name)
+            (site / "hugo.toml").write_text("title = 'Example'\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(builder.BuildError, "hugo-docs.toml"):
+                builder.load_hugo_config(
+                    site,
+                    "hugo.toml,hugo-docs.toml",
+                    "hugo",
+                    None,
+                    site / "cache",
+                )
+
+            config = builder.load_hugo_config(
+                site,
+                "hugo.toml,hugo-docs.toml",
+                "hugo",
+                None,
+                site / "cache",
+                allow_missing_config_files=True,
+            )
+            self.assertEqual(config["title"], "Example")
+
+    def test_importing_module_does_not_inherit_docs_banner(self) -> None:
+        repo_root = SCRIPT_PATH.parents[1]
+        with tempfile.TemporaryDirectory() as temp_name:
+            site = Path(temp_name)
+            (site / "go.mod").write_text(
+                "\n".join(
+                    [
+                        "module example.org/downstream-lesson",
+                        "",
+                        "go 1.26",
+                        "",
+                        "require github.com/oer-particle-physics/hugo-styles v0.0.0",
+                        "",
+                        "replace github.com/oer-particle-physics/hugo-styles "
+                        f"=> {repo_root}",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (site / "hugo.toml").write_text(
+                "\n".join(
+                    [
+                        'baseURL = "https://example.org/lesson/"',
+                        'title = "Downstream lesson"',
+                        "",
+                        "[module]",
+                        "  [[module.imports]]",
+                        '    path = "github.com/oer-particle-physics/hugo-styles"',
+                        "    [[module.imports.mounts]]",
+                        '      source = "layouts"',
+                        '      target = "layouts"',
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            completed = subprocess.run(
+                ["hugo", "config", "--quiet", "--format", "json"],
+                cwd=site,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            config = json.loads(completed.stdout)
+            self.assertNotIn("banner", config.get("params", {}))
 
 
 class DestinationTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- move the documentation-demo banner from the importable `hugo.toml` into a docs-only `hugo-docs.toml` overlay
- let the reusable Pages workflow select a Hugo config while preserving its downstream `hugo.toml` default
- keep versioned builds working when historical refs predate a secondary config overlay
- add a downstream module-import regression test and update maintainer commands

## Root cause

Hugo merges an imported module's root configuration into the consuming project. The v0.5 documentation banner therefore reached older lessons that did not define their own `params.banner`, and its `/docs/hextra-features/` link pointed to content that downstream lessons do not mount.

## Impact

Downstream lessons no longer inherit documentation-only banner settings. The `hugo-styles` documentation site retains the banner through an explicit config overlay, including in browser tests and Pages builds.

## Validation

- `python3 -m unittest discover -s scripts/tests -v`
- versioned build of the current checkout and archived `v0.4.0` with `hugo.toml,hugo-docs.toml`
- `hugo --config hugo.toml,hugo-docs.toml --gc --minify --panicOnWarning`
- `(cd cmd/hugo-styles-migrate && go test ./... && go vet ./...)`
- `npm run check:flexsearch`
- `npm run check:medium-zoom`
- `npm run test:browser` (10 passed, 8 intentionally skipped on mobile)
- `actionlint .github/workflows/pages.yml .github/workflows/reusable-pages.yml`
- `prek run --all-files`

Local Lychee is not installed; the rendered-link check remains covered by the Pages GitHub Actions workflow.
