### PR TITLE
fix: deploy pages from repository default branch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,9 @@ name: Deploy docs site
 
 on:
   push:
-    branches: ["main"]
+    # Trigger branch pushes so the job can compare against the repository's
+    # current default branch. Defining only branches also excludes tag pushes.
+    branches: ["**"]
   pull_request:
 
 permissions:
@@ -16,6 +18,9 @@ concurrency:
 
 jobs:
   pages:
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     uses: ./.github/workflows/reusable-pages.yml
     with:
       site-root: .

--- a/content/docs/deployment.md
+++ b/content/docs/deployment.md
@@ -11,13 +11,16 @@ For hosting patterns beyond this shared setup, see [Hextra Deploy Site](https://
 1. create the lesson repository from `hugo-styles-template`
 2. set `baseURL` in `hugo.toml` to `https://<account>.github.io/<repo>/`
 3. in GitHub, enable Pages and choose `GitHub Actions` as the source
-4. push `main`
+4. push the repository's default branch
 5. let the included workflow build and publish the site
 
-The included workflow deploys on pushes to `main`.
+The included workflow deploys when a push targets the branch currently configured as the repository's default in GitHub.
+Pushes to other branches create a skipped deployment run, while pull requests still run the build and link checks.
 Enable Pages before the first push so that initial deploy run already has a configured publishing target.
 By default it publishes the default branch as `Latest`.
 Extra branch or tag builds come from the `params.versioning` block in `hugo.toml`.
+Keep `params.versioning.defaultBranch` aligned with the GitHub default branch for local versioned builds, and set
+`params.lesson.editBranch` to the same branch so that edit links target the expected content.
 Before the deploy artifact is built, the workflow also builds a local-root version of the site and runs `lychee`
 against the rendered HTML on both pull requests and pushes.
 In template-based lesson repositories, the top-level workflow files are thin managed wrappers that call synced reusable workflow files maintained in `hugo-styles`.

--- a/content/docs/quickstart.md
+++ b/content/docs/quickstart.md
@@ -35,8 +35,10 @@ Use this order in a fresh lesson repository:
    while the latter is reused by lesson components and metadata snippets.
    Update `params.lesson.repo` and `params.lesson.docsRepo` because they are used for the source, edit, and citation links in the page footer.
    The top-nav GitHub icon is configured separately in `[[menus.main]]`, so update that menu URL too.
+   If the repository's default branch is not `main`, set both `params.lesson.editBranch` and
+   `params.versioning.defaultBranch` to its name.
    If you plan to deploy on GitHub Pages, set `baseURL` to `https://<account>.github.io/<repo>/`.
-   In the repository settings, enable Pages and select `GitHub Actions` as the source before the first push to `main`.
+   In the repository settings, enable Pages and select `GitHub Actions` as the source before the first push to the default branch.
 4. Add episodes with `hugo new content --kind episode episodes/my-episode/index.md`.
    Episode order is controlled by front matter `weight` (not by file or folder name).
    Use unique integer weights such as `10`, `20`, `30`; numbered slugs like `01-intro` are optional.

--- a/content/docs/versioned-sites.md
+++ b/content/docs/versioned-sites.md
@@ -29,6 +29,9 @@ The versioned builder publishes the configured default branch as `Latest` and op
     all = false
 ```
 
+Keep `defaultBranch` aligned with the repository's default branch in GitHub. The deployment workflow discovers the
+GitHub setting at runtime, while local versioned builds use this Hugo configuration value.
+
 Use `refs` for an explicit list, shell-style `patterns = ["v*"]` or `["release/*"]` for matching refs, or
 `all = true` for every local ref of that kind. A missing explicitly named ref fails the build.
 

--- a/dist/template-files/.github/workflows/pages.yml
+++ b/dist/template-files/.github/workflows/pages.yml
@@ -4,7 +4,9 @@ name: Deploy lesson
 
 on:
   push:
-    branches: ["main"]
+    # Trigger branch pushes so the job can compare against the repository's
+    # current default branch. Defining only branches also excludes tag pushes.
+    branches: ["**"]
   pull_request:
 
 permissions:
@@ -18,6 +20,9 @@ concurrency:
 
 jobs:
   pages:
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     uses: ./.github/workflows/reusable-pages.yml
     with:
       site-root: .

--- a/scripts/tests/test_pages_workflows.py
+++ b/scripts/tests/test_pages_workflows.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parents[2]
+PAGES_WORKFLOWS = (
+    REPO_ROOT / ".github" / "workflows" / "pages.yml",
+    REPO_ROOT / "dist" / "template-files" / ".github" / "workflows" / "pages.yml",
+)
+
+
+class PagesWorkflowTests(unittest.TestCase):
+    def test_pushes_are_gated_by_the_repository_default_branch(self) -> None:
+        for workflow_path in PAGES_WORKFLOWS:
+            with self.subTest(workflow=workflow_path.relative_to(REPO_ROOT)):
+                workflow = workflow_path.read_text(encoding="utf-8")
+
+                self.assertIn('branches: ["**"]', workflow)
+                self.assertNotIn('branches: ["main"]', workflow)
+                self.assertIn("github.event_name == 'pull_request' ||", workflow)
+                self.assertIn(
+                    "github.ref == format('refs/heads/{0}', "
+                    "github.event.repository.default_branch)",
+                    workflow,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- gate Pages deployments against the repository default branch reported by GitHub
- preserve pull-request validation while excluding tag pushes
- document the related Hugo branch settings and add regression coverage for both workflow copies

## Why

The managed Pages workflow hard-coded `main`, so repositories using another default branch never deployed from that branch. GitHub Actions trigger filters cannot evaluate the event context, so the workflow now triggers branch pushes and skips the reusable Pages job unless the pushed ref is the repository default branch. Non-default branch pushes therefore create only a skipped run.

Fixes #56.

## Validation

- `actionlint .github/workflows/pages.yml dist/template-files/.github/workflows/pages.yml`
- `python3 -m unittest discover -s scripts/tests -v`
- `(cd cmd/hugo-styles-migrate && go run . check ../..)`
- `hugo --config hugo.toml,hugo-docs.toml --panicOnWarning --destination .cache/current-site`
